### PR TITLE
fix: 仅在额度耗尽时才用 availabilityResetAt 作为 runtime block 回退

### DIFF
--- a/codexBar/Services/OpenAIAccountGatewayService.swift
+++ b/codexBar/Services/OpenAIAccountGatewayService.swift
@@ -915,7 +915,8 @@ final class OpenAIAccountGatewayService: OpenAIAccountGatewayControlling {
            suggestedRetryAt.timeIntervalSince(now) > 0 {
             return suggestedRetryAt
         }
-        if let availabilityResetAt = account.availabilityResetAt(now: now),
+        if account.quotaExhausted,
+           let availabilityResetAt = account.availabilityResetAt(now: now),
            availabilityResetAt.timeIntervalSince(now) > 0 {
             return availabilityResetAt
         }


### PR DESCRIPTION
## Summary

- 修复 `resolvedRuntimeBlockRetryAt` 在 in-band 限速信号不含 retry 时间时，回退到 `availabilityResetAt`（额度窗口重置时间）导致账号被 block 数小时的问题
- 加入 `account.quotaExhausted` 守卫条件，仅在额度真正耗尽时才 block 到 reset 时间，否则走 10 分钟默认兜底

## 问题描述

聚合模式下，当 OpenAI 返回 in-band 限速信号（response body 含 `rate_limit` / `usage_limit`）但不含可解析的 retry 时间时：

1. `signal.retryAt` 为 nil → `suggestedRetryAt` 跳过
2. `availabilityResetAt` 调用 `nearestResetAt`，返回 `primaryResetAt`
3. **即使账号额度远未耗尽**（0%/9%），账号仍被 block 到 `primaryResetAt`（可能数小时后）
4. 多账号同时被 block → `candidates()` 返回空 → 所有请求 503 "no routable OpenAI account"

此路径未被 commit `92190c3` 覆盖（该修复针对 HTTP 429 header 路径，而非 in-band signal 路径）。

## 改动

`OpenAIAccountGatewayService.swift` 第 918 行，增加 `account.quotaExhausted` 条件：

```diff
-        if let availabilityResetAt = account.availabilityResetAt(now: now),
+        if account.quotaExhausted,
+           let availabilityResetAt = account.availabilityResetAt(now: now),
            availabilityResetAt.timeIntervalSince(now) > 0 {
             return availabilityResetAt
         }
```

## Test plan

- [x] 重启 codexbar 后聚合模式恢复正常（清除 runtime block 验证）
- [ ] 额度未耗尽 + in-band 限速信号 → block 10 分钟而非数小时
- [ ] 额度耗尽时仍正确 block 到 reset 时间

Closes #11