### PR TITLE
新增 Requesty 内置 provider 预设

### DIFF
--- a/codexBar/Models/CodexBarProviderPreset.swift
+++ b/codexBar/Models/CodexBarProviderPreset.swift
@@ -241,6 +241,17 @@ enum CodexBarProviderPresetCatalog {
             ]
         ),
         CodexBarProviderPreset(
+            id: "requesty",
+            displayName: "Requesty",
+            group: .foreign,
+            baseURL: "https://router.requesty.ai/v1",
+            defaultModels: [
+                ("openai/gpt-4o-mini", "GPT-4o mini"),
+                ("anthropic/claude-3.7-sonnet", "Claude 3.7 Sonnet"),
+                ("google/gemini-2.5-pro", "Gemini 2.5 Pro"),
+            ]
+        ),
+        CodexBarProviderPreset(
             id: "openai-apikey",
             displayName: "OpenAI (API Key)",
             group: .foreign,


### PR DESCRIPTION
## 概述

在内置 provider 预设目录中新增 Requesty。Requesty 是一个 OpenAI 兼容的模型路由网关，采用 `provider/model` 命名（与 OpenRouter 一致）。

本次改动是**纯数据改动**：在 `CodexBarProviderPresetCatalog.foreign` 列表中追加一条预设字面量，写法与现有同类 OpenAI 兼容 foreign 预设（如 Groq、Together AI、DeepInfra）保持一致。未触碰任何枚举定义或业务逻辑。

## 实现说明

Requesty 通过标准的 `/v1/chat/completions` 端点提供服务，因此采用默认的 `kind`（`.openAICompatible`）与默认的 `wireAPI`（`.chat`），不需要也不应使用 OpenRouter 专用的 `.openRouter` / `.responses` 网关路径。鉴权方式与其他 OpenAI 兼容预设相同（`Authorization: Bearer <API Key>`）。

- baseURL：`https://router.requesty.ai/v1`
- 默认模型：
  - `openai/gpt-4o-mini`（GPT-4o mini）
  - `anthropic/claude-3.7-sonnet`（Claude 3.7 Sonnet）
  - `google/gemini-2.5-pro`（Gemini 2.5 Pro）

## 变更文件

- `codexBar/Models/CodexBarProviderPreset.swift`（+11 行，新增 1 条预设字面量）

## 验证

- 语法检查：本地存在 swift toolchain，已执行 `swift -frontend -parse codexBar/Models/CodexBarProviderPreset.swift`（以及与 `CodexBarConfig.swift` 一同解析），均无错误（exit 0）。
- 完整编译：当前环境无 Xcode / 完整 macOS 构建工具链，**未能编译整个 app**。本次为纯数据预设字面量，逐字段镜像同类 foreign 预设，正确性较为直观。
- 线上连通性：使用真实 API Key 对 `https://router.requesty.ai/v1/chat/completions` 发起请求，模型 `openai/gpt-4o-mini`，返回 HTTP 200 与真实补全结果，确认 baseURL 与命名约定有效。

## 利益相关声明

I work at Requesty. This mirrors the existing OpenRouter preset. Happy to adjust or close it if it's not a fit.
