### PR TITLE
修复 cached input 的本地计价与 token 统计

### DIFF
--- a/codexBar/Models/LocalCostSummary.swift
+++ b/codexBar/Models/LocalCostSummary.swift
@@ -8,6 +8,9 @@ struct DailyCostEntry: Identifiable, Codable {
 }
 
 struct LocalCostSummary: Codable {
+    static let currentSchemaVersion = 4
+
+    var schemaVersion: Int
     var todayCostUSD: Double
     var todayTokens: Int
     var last30DaysCostUSD: Double
@@ -27,4 +30,51 @@ struct LocalCostSummary: Codable {
         dailyEntries: [],
         updatedAt: nil
     )
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case todayCostUSD
+        case todayTokens
+        case last30DaysCostUSD
+        case last30DaysTokens
+        case lifetimeCostUSD
+        case lifetimeTokens
+        case dailyEntries
+        case updatedAt
+    }
+
+    init(
+        schemaVersion: Int = Self.currentSchemaVersion,
+        todayCostUSD: Double,
+        todayTokens: Int,
+        last30DaysCostUSD: Double,
+        last30DaysTokens: Int,
+        lifetimeCostUSD: Double,
+        lifetimeTokens: Int,
+        dailyEntries: [DailyCostEntry],
+        updatedAt: Date?
+    ) {
+        self.schemaVersion = schemaVersion
+        self.todayCostUSD = todayCostUSD
+        self.todayTokens = todayTokens
+        self.last30DaysCostUSD = last30DaysCostUSD
+        self.last30DaysTokens = last30DaysTokens
+        self.lifetimeCostUSD = lifetimeCostUSD
+        self.lifetimeTokens = lifetimeTokens
+        self.dailyEntries = dailyEntries
+        self.updatedAt = updatedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 0
+        self.todayCostUSD = try container.decode(Double.self, forKey: .todayCostUSD)
+        self.todayTokens = try container.decode(Int.self, forKey: .todayTokens)
+        self.last30DaysCostUSD = try container.decode(Double.self, forKey: .last30DaysCostUSD)
+        self.last30DaysTokens = try container.decode(Int.self, forKey: .last30DaysTokens)
+        self.lifetimeCostUSD = try container.decode(Double.self, forKey: .lifetimeCostUSD)
+        self.lifetimeTokens = try container.decode(Int.self, forKey: .lifetimeTokens)
+        self.dailyEntries = try container.decode([DailyCostEntry].self, forKey: .dailyEntries)
+        self.updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt)
+    }
 }

--- a/codexBar/Services/LocalCostSummaryService.swift
+++ b/codexBar/Services/LocalCostSummaryService.swift
@@ -59,15 +59,16 @@ enum LocalCostPricing {
         let pricing = self.effectivePricing(for: normalizedModel, customPricingByModel: customPricingByModel)
         let input = max(0, usage.inputTokens)
         let cached = max(0, usage.cachedInputTokens)
+        let billableInput = max(0, input - cached)
         let longContextRateMultiplier = self.usesLongContextPremium(
             model: normalizedModel,
-            sessionUsage: sessionUsage
+            usage: usage
         )
         ? 2.0
         : 1.0
         let outputRateMultiplier = longContextRateMultiplier > 1 ? 1.5 : 1.0
 
-        return Double(input) * pricing.inputUSDPerToken * longContextRateMultiplier +
+        return Double(billableInput) * pricing.inputUSDPerToken * longContextRateMultiplier +
             Double(cached) * pricing.cachedInputUSDPerToken +
             Double(usage.outputTokens) * pricing.outputUSDPerToken * outputRateMultiplier
     }
@@ -87,10 +88,9 @@ enum LocalCostPricing {
 
     private static func usesLongContextPremium(
         model: String,
-        sessionUsage: SessionLogStore.Usage?
+        usage: SessionLogStore.Usage
     ) -> Bool {
-        guard let sessionUsage,
-              sessionUsage.inputTokens > self.longContextInputThreshold else {
+        guard usage.inputTokens > self.longContextInputThreshold else {
             return false
         }
 

--- a/codexBar/Services/LocalCostSummaryService.swift
+++ b/codexBar/Services/LocalCostSummaryService.swift
@@ -69,7 +69,7 @@ enum LocalCostPricing {
         let outputRateMultiplier = longContextRateMultiplier > 1 ? 1.5 : 1.0
 
         return Double(billableInput) * pricing.inputUSDPerToken * longContextRateMultiplier +
-            Double(cached) * pricing.cachedInputUSDPerToken +
+            Double(cached) * pricing.cachedInputUSDPerToken * longContextRateMultiplier +
             Double(usage.outputTokens) * pricing.outputUSDPerToken * outputRateMultiplier
     }
 

--- a/codexBar/Services/SessionLogStore.swift
+++ b/codexBar/Services/SessionLogStore.swift
@@ -16,7 +16,7 @@ final class SessionLogStore: @unchecked Sendable, RecordsSourceSnapshotLoading {
         nonisolated static let zero = Usage(inputTokens: 0, cachedInputTokens: 0, outputTokens: 0)
 
         nonisolated var totalTokens: Int {
-            self.inputTokens + self.cachedInputTokens + self.outputTokens
+            self.inputTokens + self.outputTokens
         }
 
         nonisolated var isZero: Bool {

--- a/codexBar/Services/TokenStore.swift
+++ b/codexBar/Services/TokenStore.swift
@@ -1518,6 +1518,10 @@ final class TokenStore: ObservableObject {
     }
 
     private func shouldInvalidateCachedLocalCostSummary(_ summary: LocalCostSummary) -> Bool {
+        guard summary.schemaVersion == LocalCostSummary.currentSchemaVersion else {
+            return true
+        }
+
         guard summary.updatedAt != nil,
               self.isEffectivelyEmptyLocalCostSummary(summary) else {
             return false

--- a/codexBarTests/LocalCostSummaryServiceTests.swift
+++ b/codexBarTests/LocalCostSummaryServiceTests.swift
@@ -56,6 +56,21 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
         let costUSD: Double
     }
 
+    func testPricingTreatsCachedInputAsInputSubset() {
+        let usage = SessionLogStore.Usage(
+            inputTokens: 100,
+            cachedInputTokens: 80,
+            outputTokens: 10
+        )
+
+        XCTAssertEqual(usage.totalTokens, 110)
+        XCTAssertEqual(
+            LocalCostPricing.costUSD(model: "gpt-5.5", usage: usage),
+            0.00044,
+            accuracy: 1e-12
+        )
+    }
+
     func testLoadAggregatesSessionsAcrossFastAndSlowPaths() throws {
         let home = try self.makeCodexHome()
         let service = self.makeService(home: home)
@@ -93,22 +108,22 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
 
         let summary = service.load(now: self.date("2026-04-05T12:00:00Z"))
 
-        XCTAssertEqual(summary.todayTokens, 170)
-        XCTAssertEqual(summary.last30DaysTokens, 460)
-        XCTAssertEqual(summary.lifetimeTokens, 2_458)
+        XCTAssertEqual(summary.todayTokens, 150)
+        XCTAssertEqual(summary.last30DaysTokens, 390)
+        XCTAssertEqual(summary.lifetimeTokens, 2_388)
         XCTAssertEqual(summary.dailyEntries.count, 3)
 
-        XCTAssertEqual(summary.todayCostUSD, 0.00201, accuracy: 1e-12)
-        XCTAssertEqual(summary.last30DaysCostUSD, 0.00214125, accuracy: 1e-12)
-        XCTAssertEqual(summary.lifetimeCostUSD, 0.00214125, accuracy: 1e-12)
+        XCTAssertEqual(summary.todayCostUSD, 0.00191, accuracy: 1e-12)
+        XCTAssertEqual(summary.last30DaysCostUSD, 0.00202875, accuracy: 1e-12)
+        XCTAssertEqual(summary.lifetimeCostUSD, 0.00202875, accuracy: 1e-12)
 
         XCTAssertEqual(summary.dailyEntries[0].date, self.date("2026-04-05T00:00:00Z"))
-        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 170)
-        XCTAssertEqual(summary.dailyEntries[0].costUSD, 0.00201, accuracy: 1e-12)
+        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 150)
+        XCTAssertEqual(summary.dailyEntries[0].costUSD, 0.00191, accuracy: 1e-12)
 
         XCTAssertEqual(summary.dailyEntries[1].date, self.date("2026-04-03T00:00:00Z"))
-        XCTAssertEqual(summary.dailyEntries[1].totalTokens, 290)
-        XCTAssertEqual(summary.dailyEntries[1].costUSD, 0.00013125, accuracy: 1e-12)
+        XCTAssertEqual(summary.dailyEntries[1].totalTokens, 240)
+        XCTAssertEqual(summary.dailyEntries[1].costUSD, 0.00011875, accuracy: 1e-12)
 
         XCTAssertEqual(summary.dailyEntries[2].date, self.date("2026-03-01T00:00:00Z"))
         XCTAssertEqual(summary.dailyEntries[2].totalTokens, 1_998)
@@ -141,8 +156,8 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
         )
 
         let initialSummary = service.load(now: self.date("2026-04-05T12:00:00Z"))
-        XCTAssertEqual(initialSummary.todayTokens, 130)
-        XCTAssertEqual(initialSummary.todayCostUSD, 0.00016575, accuracy: 1e-12)
+        XCTAssertEqual(initialSummary.todayTokens, 120)
+        XCTAssertEqual(initialSummary.todayCostUSD, 0.00015825, accuracy: 1e-12)
 
         try self.writeFastSession(
             directory: sessionDirectory,
@@ -157,8 +172,8 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
         )
 
         let updatedSummary = service.load(now: self.date("2026-04-05T12:00:00Z"))
-        XCTAssertEqual(updatedSummary.todayTokens, 260)
-        XCTAssertEqual(updatedSummary.todayCostUSD, 0.00037575, accuracy: 1e-12)
+        XCTAssertEqual(updatedSummary.todayTokens, 250)
+        XCTAssertEqual(updatedSummary.todayCostUSD, 0.00036825, accuracy: 1e-12)
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: cacheURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: ledgerURL.path))
@@ -183,8 +198,8 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
         )
 
         let initialSummary = service.load(now: self.date("2026-04-05T12:00:00Z"))
-        XCTAssertEqual(initialSummary.todayTokens, 140)
-        XCTAssertEqual(initialSummary.todayCostUSD, 0.00111, accuracy: 1e-12)
+        XCTAssertEqual(initialSummary.todayTokens, 120)
+        XCTAssertEqual(initialSummary.todayCostUSD, 0.00101, accuracy: 1e-12)
 
         try self.writeFastSession(
             directory: sessionDirectory,
@@ -199,11 +214,11 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
         )
 
         let updatedSummary = service.load(now: self.date("2026-04-05T12:30:00Z"))
-        XCTAssertEqual(updatedSummary.todayTokens, 280)
-        XCTAssertEqual(updatedSummary.todayCostUSD, 0.00222, accuracy: 1e-12)
+        XCTAssertEqual(updatedSummary.todayTokens, 240)
+        XCTAssertEqual(updatedSummary.todayCostUSD, 0.00202, accuracy: 1e-12)
         XCTAssertEqual(updatedSummary.dailyEntries.count, 1)
-        XCTAssertEqual(updatedSummary.dailyEntries[0].totalTokens, 280)
-        XCTAssertEqual(updatedSummary.dailyEntries[0].costUSD, 0.00222, accuracy: 1e-12)
+        XCTAssertEqual(updatedSummary.dailyEntries[0].totalTokens, 240)
+        XCTAssertEqual(updatedSummary.dailyEntries[0].costUSD, 0.00202, accuracy: 1e-12)
     }
 
     func testLoadDoesNotDoubleCountDuplicateTokenCountLines() throws {
@@ -226,15 +241,15 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
 
         let summary = service.load(now: self.date("2026-04-05T12:00:00Z"))
 
-        XCTAssertEqual(summary.todayTokens, 230)
-        XCTAssertEqual(summary.last30DaysTokens, 230)
-        XCTAssertEqual(summary.lifetimeTokens, 230)
-        XCTAssertEqual(summary.todayCostUSD, 0.001765, accuracy: 1e-12)
-        XCTAssertEqual(summary.last30DaysCostUSD, 0.001765, accuracy: 1e-12)
-        XCTAssertEqual(summary.lifetimeCostUSD, 0.001765, accuracy: 1e-12)
+        XCTAssertEqual(summary.todayTokens, 200)
+        XCTAssertEqual(summary.last30DaysTokens, 200)
+        XCTAssertEqual(summary.lifetimeTokens, 200)
+        XCTAssertEqual(summary.todayCostUSD, 0.001615, accuracy: 1e-12)
+        XCTAssertEqual(summary.last30DaysCostUSD, 0.001615, accuracy: 1e-12)
+        XCTAssertEqual(summary.lifetimeCostUSD, 0.001615, accuracy: 1e-12)
         XCTAssertEqual(summary.dailyEntries.count, 1)
-        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 230)
-        XCTAssertEqual(summary.dailyEntries[0].costUSD, 0.001765, accuracy: 1e-12)
+        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 200)
+        XCTAssertEqual(summary.dailyEntries[0].costUSD, 0.001615, accuracy: 1e-12)
     }
 
     func testLoadDoesNotDoubleCountReplayedTokenCountBlocksAfterTotalDrops() throws {
@@ -258,15 +273,15 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
 
         let summary = service.load(now: self.date("2026-04-05T12:00:00Z"))
 
-        XCTAssertEqual(summary.todayTokens, 300)
-        XCTAssertEqual(summary.last30DaysTokens, 300)
-        XCTAssertEqual(summary.lifetimeTokens, 300)
-        XCTAssertEqual(summary.todayCostUSD, 0.00232, accuracy: 1e-12)
-        XCTAssertEqual(summary.last30DaysCostUSD, 0.00232, accuracy: 1e-12)
-        XCTAssertEqual(summary.lifetimeCostUSD, 0.00232, accuracy: 1e-12)
+        XCTAssertEqual(summary.todayTokens, 260)
+        XCTAssertEqual(summary.last30DaysTokens, 260)
+        XCTAssertEqual(summary.lifetimeTokens, 260)
+        XCTAssertEqual(summary.todayCostUSD, 0.00212, accuracy: 1e-12)
+        XCTAssertEqual(summary.last30DaysCostUSD, 0.00212, accuracy: 1e-12)
+        XCTAssertEqual(summary.lifetimeCostUSD, 0.00212, accuracy: 1e-12)
         XCTAssertEqual(summary.dailyEntries.count, 1)
-        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 300)
-        XCTAssertEqual(summary.dailyEntries[0].costUSD, 0.00232, accuracy: 1e-12)
+        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 260)
+        XCTAssertEqual(summary.dailyEntries[0].costUSD, 0.00212, accuracy: 1e-12)
     }
 
     func testLoadDoesNotDoubleCountSameSessionAcrossCurrentAndArchivedDirectories() throws {
@@ -298,15 +313,15 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
 
         let summary = service.load(now: self.date("2026-04-05T12:00:00Z"))
 
-        XCTAssertEqual(summary.todayTokens, 230)
-        XCTAssertEqual(summary.last30DaysTokens, 230)
-        XCTAssertEqual(summary.lifetimeTokens, 230)
-        XCTAssertEqual(summary.todayCostUSD, 0.001765, accuracy: 1e-12)
-        XCTAssertEqual(summary.last30DaysCostUSD, 0.001765, accuracy: 1e-12)
-        XCTAssertEqual(summary.lifetimeCostUSD, 0.001765, accuracy: 1e-12)
+        XCTAssertEqual(summary.todayTokens, 200)
+        XCTAssertEqual(summary.last30DaysTokens, 200)
+        XCTAssertEqual(summary.lifetimeTokens, 200)
+        XCTAssertEqual(summary.todayCostUSD, 0.001615, accuracy: 1e-12)
+        XCTAssertEqual(summary.last30DaysCostUSD, 0.001615, accuracy: 1e-12)
+        XCTAssertEqual(summary.lifetimeCostUSD, 0.001615, accuracy: 1e-12)
         XCTAssertEqual(summary.dailyEntries.count, 1)
-        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 230)
-        XCTAssertEqual(summary.dailyEntries[0].costUSD, 0.001765, accuracy: 1e-12)
+        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 200)
+        XCTAssertEqual(summary.dailyEntries[0].costUSD, 0.001615, accuracy: 1e-12)
     }
 
     func testLoadKeepsObservedTotalsAfterArchivedTokenOnlyRewrite() throws {
@@ -328,8 +343,8 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
         )
 
         let initialSummary = service.load(now: self.date("2026-04-05T12:00:00Z"))
-        XCTAssertEqual(initialSummary.todayTokens, 230)
-        XCTAssertEqual(initialSummary.todayCostUSD, 0.001765, accuracy: 1e-12)
+        XCTAssertEqual(initialSummary.todayTokens, 200)
+        XCTAssertEqual(initialSummary.todayCostUSD, 0.001615, accuracy: 1e-12)
 
         try FileManager.default.removeItem(at: currentDirectory.appendingPathComponent("rollback.jsonl"))
         try self.writeTokenOnlySession(
@@ -447,15 +462,15 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
 
         let summary = self.makeService(home: home).load(now: self.date("2026-04-05T12:00:00Z"))
 
-        XCTAssertEqual(summary.todayTokens, 230)
-        XCTAssertEqual(summary.last30DaysTokens, 230)
-        XCTAssertEqual(summary.lifetimeTokens, 230)
-        XCTAssertEqual(summary.todayCostUSD, 0.001765, accuracy: 1e-12)
-        XCTAssertEqual(summary.last30DaysCostUSD, 0.001765, accuracy: 1e-12)
-        XCTAssertEqual(summary.lifetimeCostUSD, 0.001765, accuracy: 1e-12)
+        XCTAssertEqual(summary.todayTokens, 200)
+        XCTAssertEqual(summary.last30DaysTokens, 200)
+        XCTAssertEqual(summary.lifetimeTokens, 200)
+        XCTAssertEqual(summary.todayCostUSD, 0.001615, accuracy: 1e-12)
+        XCTAssertEqual(summary.last30DaysCostUSD, 0.001615, accuracy: 1e-12)
+        XCTAssertEqual(summary.lifetimeCostUSD, 0.001615, accuracy: 1e-12)
         XCTAssertEqual(summary.dailyEntries.count, 1)
-        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 230)
-        XCTAssertEqual(summary.dailyEntries[0].costUSD, 0.001765, accuracy: 1e-12)
+        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 200)
+        XCTAssertEqual(summary.dailyEntries[0].costUSD, 0.001615, accuracy: 1e-12)
     }
 
     func testLoadRepairsCurrentSessionLedgerWhenPersistedLedgerContainsDuplicates() throws {
@@ -497,15 +512,15 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
 
         let summary = self.makeService(home: home).load(now: self.date("2026-04-05T12:00:00Z"))
 
-        XCTAssertEqual(summary.todayTokens, 230)
-        XCTAssertEqual(summary.last30DaysTokens, 230)
-        XCTAssertEqual(summary.lifetimeTokens, 230)
-        XCTAssertEqual(summary.todayCostUSD, 0.001765, accuracy: 1e-12)
-        XCTAssertEqual(summary.last30DaysCostUSD, 0.001765, accuracy: 1e-12)
-        XCTAssertEqual(summary.lifetimeCostUSD, 0.001765, accuracy: 1e-12)
+        XCTAssertEqual(summary.todayTokens, 200)
+        XCTAssertEqual(summary.last30DaysTokens, 200)
+        XCTAssertEqual(summary.lifetimeTokens, 200)
+        XCTAssertEqual(summary.todayCostUSD, 0.001615, accuracy: 1e-12)
+        XCTAssertEqual(summary.last30DaysCostUSD, 0.001615, accuracy: 1e-12)
+        XCTAssertEqual(summary.lifetimeCostUSD, 0.001615, accuracy: 1e-12)
         XCTAssertEqual(summary.dailyEntries.count, 1)
-        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 230)
-        XCTAssertEqual(summary.dailyEntries[0].costUSD, 0.001765, accuracy: 1e-12)
+        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 200)
+        XCTAssertEqual(summary.dailyEntries[0].costUSD, 0.001615, accuracy: 1e-12)
     }
 
     func testLoadAttributesCrossDaySessionUsageToEventDayAndPreservesBucketsAfterRewrite() throws {
@@ -526,22 +541,22 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
 
         let summary = service.load(now: self.date("2026-04-05T12:00:00Z"))
 
-        XCTAssertEqual(summary.todayTokens, 90)
-        XCTAssertEqual(summary.last30DaysTokens, 230)
-        XCTAssertEqual(summary.lifetimeTokens, 230)
+        XCTAssertEqual(summary.todayTokens, 80)
+        XCTAssertEqual(summary.last30DaysTokens, 200)
+        XCTAssertEqual(summary.lifetimeTokens, 200)
         XCTAssertEqual(summary.dailyEntries.count, 2)
 
         XCTAssertEqual(summary.dailyEntries[0].date, self.date("2026-04-05T00:00:00Z"))
-        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 90)
-        XCTAssertEqual(summary.dailyEntries[0].costUSD, 0.000655, accuracy: 1e-12)
+        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 80)
+        XCTAssertEqual(summary.dailyEntries[0].costUSD, 0.000605, accuracy: 1e-12)
 
         XCTAssertEqual(summary.dailyEntries[1].date, self.date("2026-04-04T00:00:00Z"))
-        XCTAssertEqual(summary.dailyEntries[1].totalTokens, 140)
-        XCTAssertEqual(summary.dailyEntries[1].costUSD, 0.00111, accuracy: 1e-12)
+        XCTAssertEqual(summary.dailyEntries[1].totalTokens, 120)
+        XCTAssertEqual(summary.dailyEntries[1].costUSD, 0.00101, accuracy: 1e-12)
 
-        XCTAssertEqual(summary.todayCostUSD, 0.000655, accuracy: 1e-12)
-        XCTAssertEqual(summary.last30DaysCostUSD, 0.001765, accuracy: 1e-12)
-        XCTAssertEqual(summary.lifetimeCostUSD, 0.001765, accuracy: 1e-12)
+        XCTAssertEqual(summary.todayCostUSD, 0.000605, accuracy: 1e-12)
+        XCTAssertEqual(summary.last30DaysCostUSD, 0.001615, accuracy: 1e-12)
+        XCTAssertEqual(summary.lifetimeCostUSD, 0.001615, accuracy: 1e-12)
 
         try self.writeTokenOnlySession(
             directory: codexRoot.appendingPathComponent("archived_sessions", isDirectory: true),
@@ -579,7 +594,7 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
 
         let initialService = self.makeService(home: home)
         let initialSummary = initialService.load(now: self.date("2026-04-05T12:00:00Z"))
-        XCTAssertEqual(initialSummary.todayCostUSD, 0.00111, accuracy: 1e-12)
+        XCTAssertEqual(initialSummary.todayCostUSD, 0.00101, accuracy: 1e-12)
 
         let repricedSummary = initialService.load(
             now: self.date("2026-04-05T12:00:00Z"),
@@ -592,15 +607,15 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
             ]
         )
 
-        XCTAssertEqual(repricedSummary.todayTokens, 140)
-        XCTAssertEqual(repricedSummary.last30DaysTokens, 140)
-        XCTAssertEqual(repricedSummary.lifetimeTokens, 140)
-        XCTAssertEqual(repricedSummary.todayCostUSD, 150, accuracy: 1e-9)
-        XCTAssertEqual(repricedSummary.last30DaysCostUSD, 150, accuracy: 1e-9)
-        XCTAssertEqual(repricedSummary.lifetimeCostUSD, 150, accuracy: 1e-9)
+        XCTAssertEqual(repricedSummary.todayTokens, 120)
+        XCTAssertEqual(repricedSummary.last30DaysTokens, 120)
+        XCTAssertEqual(repricedSummary.lifetimeTokens, 120)
+        XCTAssertEqual(repricedSummary.todayCostUSD, 130, accuracy: 1e-9)
+        XCTAssertEqual(repricedSummary.last30DaysCostUSD, 130, accuracy: 1e-9)
+        XCTAssertEqual(repricedSummary.lifetimeCostUSD, 130, accuracy: 1e-9)
         XCTAssertEqual(repricedSummary.dailyEntries.count, 1)
-        XCTAssertEqual(repricedSummary.dailyEntries[0].totalTokens, 140)
-        XCTAssertEqual(repricedSummary.dailyEntries[0].costUSD, 150, accuracy: 1e-9)
+        XCTAssertEqual(repricedSummary.dailyEntries[0].totalTokens, 120)
+        XCTAssertEqual(repricedSummary.dailyEntries[0].costUSD, 130, accuracy: 1e-9)
     }
 
     func testLoadUsesKnownOpenAIPricingForModelVariants() throws {
@@ -627,9 +642,9 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
         let summary = service.load(now: self.date("2026-04-05T12:00:00Z"))
         let expectedCost = LocalCostPricing.costUSD(model: "gpt-5.3-codex", usage: usage)
 
-        XCTAssertEqual(summary.todayTokens, 155)
-        XCTAssertEqual(summary.last30DaysTokens, 155)
-        XCTAssertEqual(summary.lifetimeTokens, 155)
+        XCTAssertEqual(summary.todayTokens, 130)
+        XCTAssertEqual(summary.last30DaysTokens, 130)
+        XCTAssertEqual(summary.lifetimeTokens, 130)
         XCTAssertEqual(summary.todayCostUSD, expectedCost, accuracy: 1e-12)
         XCTAssertEqual(summary.last30DaysCostUSD, expectedCost, accuracy: 1e-12)
         XCTAssertEqual(summary.lifetimeCostUSD, expectedCost, accuracy: 1e-12)
@@ -664,17 +679,73 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
             usage: usage,
             sessionUsage: usage
         )
-        let baselineCost = LocalCostPricing.costUSD(model: "gpt-5.5", usage: usage)
+        let nonPremiumCost =
+            Double(usage.inputTokens - usage.cachedInputTokens) * 5e-6 +
+            Double(usage.cachedInputTokens) * 5e-7 +
+            Double(usage.outputTokens) * 30e-6
 
-        XCTAssertGreaterThan(expectedCost, baselineCost)
-        XCTAssertEqual(summary.todayTokens, 321_000)
-        XCTAssertEqual(summary.last30DaysTokens, 321_000)
-        XCTAssertEqual(summary.lifetimeTokens, 321_000)
+        XCTAssertGreaterThan(expectedCost, nonPremiumCost)
+        XCTAssertEqual(summary.todayTokens, 301_000)
+        XCTAssertEqual(summary.last30DaysTokens, 301_000)
+        XCTAssertEqual(summary.lifetimeTokens, 301_000)
         XCTAssertEqual(summary.todayCostUSD, expectedCost, accuracy: 1e-12)
         XCTAssertEqual(summary.last30DaysCostUSD, expectedCost, accuracy: 1e-12)
         XCTAssertEqual(summary.lifetimeCostUSD, expectedCost, accuracy: 1e-12)
         XCTAssertEqual(summary.dailyEntries.count, 1)
-        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 321_000)
+        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 301_000)
+        XCTAssertEqual(summary.dailyEntries[0].costUSD, expectedCost, accuracy: 1e-12)
+    }
+
+    func testLoadDoesNotApplyLongContextPremiumToSmallRequestsInLargeSession() throws {
+        let home = try self.makeCodexHome()
+        let codexRoot = home.appendingPathComponent(".codex", isDirectory: true)
+        let service = self.makeService(home: home)
+        let firstUsage = SessionLogStore.Usage(
+            inputTokens: 200_000,
+            cachedInputTokens: 150_000,
+            outputTokens: 1_000
+        )
+        let secondUsage = SessionLogStore.Usage(
+            inputTokens: 200_000,
+            cachedInputTokens: 150_000,
+            outputTokens: 1_000
+        )
+
+        try self.writeSession(
+            directory: codexRoot.appendingPathComponent("sessions", isDirectory: true),
+            fileName: "gpt55-large-cumulative-session.jsonl",
+            lines: [
+                #"{"payload":{"type":"session_meta","id":"gpt55-large-cumulative-session","timestamp":"2026-04-05T08:00:00Z"}}"#,
+                #"{"payload":{"type":"turn_context","model":"gpt-5.5"}}"#,
+                #"{"timestamp":"2026-04-05T08:05:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":200000,"cached_input_tokens":150000,"output_tokens":1000},"last_token_usage":{"input_tokens":200000,"cached_input_tokens":150000,"output_tokens":1000}}}}"#,
+                #"{"timestamp":"2026-04-05T08:10:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":400000,"cached_input_tokens":300000,"output_tokens":2000},"last_token_usage":{"input_tokens":200000,"cached_input_tokens":150000,"output_tokens":1000}}}}"#,
+            ]
+        )
+
+        let summary = service.load(now: self.date("2026-04-05T12:00:00Z"))
+        let expectedCost =
+            LocalCostPricing.costUSD(model: "gpt-5.5", usage: firstUsage) +
+            LocalCostPricing.costUSD(model: "gpt-5.5", usage: secondUsage)
+        let incorrectlyPremiumedCost =
+            LocalCostPricing.costUSD(
+                model: "gpt-5.5",
+                usage: firstUsage,
+                sessionUsage: firstUsage + secondUsage
+            ) +
+            LocalCostPricing.costUSD(
+                model: "gpt-5.5",
+                usage: secondUsage,
+                sessionUsage: firstUsage + secondUsage
+            )
+
+        XCTAssertEqual(expectedCost, incorrectlyPremiumedCost, accuracy: 1e-12)
+        XCTAssertEqual(summary.todayTokens, 402_000)
+        XCTAssertEqual(summary.last30DaysTokens, 402_000)
+        XCTAssertEqual(summary.lifetimeTokens, 402_000)
+        XCTAssertEqual(summary.todayCostUSD, expectedCost, accuracy: 1e-12)
+        XCTAssertEqual(summary.last30DaysCostUSD, expectedCost, accuracy: 1e-12)
+        XCTAssertEqual(summary.lifetimeCostUSD, expectedCost, accuracy: 1e-12)
+        XCTAssertEqual(summary.dailyEntries.count, 1)
         XCTAssertEqual(summary.dailyEntries[0].costUSD, expectedCost, accuracy: 1e-12)
     }
 
@@ -723,9 +794,9 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
             sessionUsage: usage
         )
 
-        XCTAssertEqual(summary.todayTokens, 155)
-        XCTAssertEqual(summary.last30DaysTokens, 155)
-        XCTAssertEqual(summary.lifetimeTokens, 155)
+        XCTAssertEqual(summary.todayTokens, 130)
+        XCTAssertEqual(summary.last30DaysTokens, 130)
+        XCTAssertEqual(summary.lifetimeTokens, 130)
         XCTAssertEqual(summary.todayCostUSD, expectedCost, accuracy: 1e-12)
         XCTAssertEqual(summary.last30DaysCostUSD, expectedCost, accuracy: 1e-12)
         XCTAssertEqual(summary.lifetimeCostUSD, expectedCost, accuracy: 1e-12)
@@ -760,14 +831,14 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
 
         let summary = service.load(now: self.date("2026-04-05T12:00:00Z"))
 
-        XCTAssertEqual(summary.todayTokens, 155)
-        XCTAssertEqual(summary.last30DaysTokens, 155)
-        XCTAssertEqual(summary.lifetimeTokens, 155)
+        XCTAssertEqual(summary.todayTokens, 130)
+        XCTAssertEqual(summary.last30DaysTokens, 130)
+        XCTAssertEqual(summary.lifetimeTokens, 130)
         XCTAssertEqual(summary.todayCostUSD, 0, accuracy: 1e-12)
         XCTAssertEqual(summary.last30DaysCostUSD, 0, accuracy: 1e-12)
         XCTAssertEqual(summary.lifetimeCostUSD, 0, accuracy: 1e-12)
         XCTAssertEqual(summary.dailyEntries.count, 1)
-        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 155)
+        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 130)
         XCTAssertEqual(summary.dailyEntries[0].costUSD, 0, accuracy: 1e-12)
     }
 
@@ -877,12 +948,12 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
             refreshSessionCache: false
         )
 
-        XCTAssertEqual(summary.todayTokens, 230)
-        XCTAssertEqual(summary.last30DaysTokens, 230)
-        XCTAssertEqual(summary.lifetimeTokens, 230)
-        XCTAssertEqual(summary.todayCostUSD, 0.001765, accuracy: 1e-12)
+        XCTAssertEqual(summary.todayTokens, 200)
+        XCTAssertEqual(summary.last30DaysTokens, 200)
+        XCTAssertEqual(summary.lifetimeTokens, 200)
+        XCTAssertEqual(summary.todayCostUSD, 0.001615, accuracy: 1e-12)
         XCTAssertEqual(summary.dailyEntries.count, 1)
-        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 230)
+        XCTAssertEqual(summary.dailyEntries[0].totalTokens, 200)
     }
 
     private func makeCodexHome() throws -> URL {

--- a/codexBarTests/LocalCostSummaryServiceTests.swift
+++ b/codexBarTests/LocalCostSummaryServiceTests.swift
@@ -684,6 +684,7 @@ final class LocalCostSummaryServiceTests: CodexBarTestCase {
             Double(usage.cachedInputTokens) * 5e-7 +
             Double(usage.outputTokens) * 30e-6
 
+        XCTAssertEqual(expectedCost, 2.865, accuracy: 1e-12)
         XCTAssertGreaterThan(expectedCost, nonPremiumCost)
         XCTAssertEqual(summary.todayTokens, 301_000)
         XCTAssertEqual(summary.last30DaysTokens, 301_000)

--- a/codexBarTests/TokenStoreSettingsTests.swift
+++ b/codexBarTests/TokenStoreSettingsTests.swift
@@ -129,14 +129,78 @@ final class TokenStoreSettingsTests: CodexBarTestCase {
 
         XCTAssertNotNil(store.localCostSummary.updatedAt)
         XCTAssertEqual(store.localCostSummary.todayTokens, 0)
-        XCTAssertEqual(store.localCostSummary.last30DaysTokens, 230)
-        XCTAssertEqual(store.localCostSummary.lifetimeTokens, 230)
-        XCTAssertEqual(store.localCostSummary.last30DaysCostUSD, 0.001765, accuracy: 1e-12)
-        XCTAssertEqual(store.localCostSummary.lifetimeCostUSD, 0.001765, accuracy: 1e-12)
+        XCTAssertEqual(store.localCostSummary.last30DaysTokens, 200)
+        XCTAssertEqual(store.localCostSummary.lifetimeTokens, 200)
+        XCTAssertEqual(store.localCostSummary.last30DaysCostUSD, 0.001615, accuracy: 1e-12)
+        XCTAssertEqual(store.localCostSummary.lifetimeCostUSD, 0.001615, accuracy: 1e-12)
         XCTAssertEqual(store.localCostSummary.dailyEntries.count, 1)
-        XCTAssertEqual(store.localCostSummary.dailyEntries[0].totalTokens, 230)
-        XCTAssertEqual(store.localCostSummary.dailyEntries[0].costUSD, 0.001765, accuracy: 1e-12)
+        XCTAssertEqual(store.localCostSummary.dailyEntries[0].totalTokens, 200)
+        XCTAssertEqual(store.localCostSummary.dailyEntries[0].costUSD, 0.001615, accuracy: 1e-12)
         XCTAssertTrue(FileManager.default.fileExists(atPath: CodexPaths.costCacheURL.path))
+    }
+
+    func testInitializationRebuildsLocalCostSummaryWhenCachedSchemaIsLegacy() throws {
+        let fixture = Self.recentCostFixtureTimestamps()
+        let sessionDirectory = CodexPaths.codexRoot.appendingPathComponent("sessions", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionDirectory, withIntermediateDirectories: true)
+        let sessionURL = sessionDirectory.appendingPathComponent("cost-legacy-cache.jsonl")
+        let content = [
+            #"{"payload":{"type":"session_meta","id":"cost-legacy-cache","timestamp":"\#(fixture.sessionStartedAt)"}}"#,
+            #"{"payload":{"type":"turn_context","model":"gpt-5.5"}}"#,
+            #"{"timestamp":"\#(fixture.firstUsageAt)","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":20},"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":20}}}}"#,
+            #"{"timestamp":"\#(fixture.secondUsageAt)","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":170,"cached_input_tokens":30,"output_tokens":30},"last_token_usage":{"input_tokens":70,"cached_input_tokens":10,"output_tokens":10}}}}"#,
+        ].joined(separator: "\n") + "\n"
+        try content.write(to: sessionURL, atomically: true, encoding: .utf8)
+
+        let legacyCache = """
+        {
+          "todayCostUSD": 659,
+          "todayTokens": 3710000,
+          "last30DaysCostUSD": 19906.99,
+          "last30DaysTokens": 20190000000,
+          "lifetimeCostUSD": 22684.09,
+          "lifetimeTokens": 23290000000,
+          "dailyEntries": [
+            {
+              "id": "2026-06-01T00:00:00Z",
+              "date": "2026-06-01T00:00:00Z",
+              "costUSD": 17329.25,
+              "totalTokens": 17970000000
+            }
+          ],
+          "updatedAt": "2026-06-17T04:27:52Z"
+        }
+        """
+        try CodexPaths.writeSecureFile(Data(legacyCache.utf8), to: CodexPaths.costCacheURL)
+
+        let sessionStore = SessionLogStore(
+            codexRootURL: CodexPaths.codexRoot,
+            persistedCacheURL: URL(fileURLWithPath: ProcessInfo.processInfo.environment["CODEXBAR_HOME"] ?? NSTemporaryDirectory())
+                .appendingPathComponent(".codexbar/test-cost-session-cache.json"),
+            persistedUsageLedgerURL: URL(fileURLWithPath: ProcessInfo.processInfo.environment["CODEXBAR_HOME"] ?? NSTemporaryDirectory())
+                .appendingPathComponent(".codexbar/test-cost-event-ledger.json")
+        )
+        let store = self.makeTokenStore(
+            costSummaryService: LocalCostSummaryService(sessionLogStore: sessionStore),
+            openRouterCatalogService: OpenRouterModelCatalogServiceSpy(
+                result: .failure(URLError(.notConnectedToInternet))
+            )
+        )
+
+        let timeout = Date().addingTimeInterval(3)
+        while store.localCostSummary.last30DaysTokens != 200 && Date() < timeout {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        }
+
+        XCTAssertEqual(store.localCostSummary.schemaVersion, LocalCostSummary.currentSchemaVersion)
+        XCTAssertEqual(store.localCostSummary.todayTokens, 0)
+        XCTAssertEqual(store.localCostSummary.last30DaysTokens, 200)
+        XCTAssertEqual(store.localCostSummary.lifetimeTokens, 200)
+        XCTAssertEqual(store.localCostSummary.last30DaysCostUSD, 0.001615, accuracy: 1e-12)
+        XCTAssertEqual(store.localCostSummary.lifetimeCostUSD, 0.001615, accuracy: 1e-12)
+        XCTAssertEqual(store.localCostSummary.dailyEntries.count, 1)
+        XCTAssertEqual(store.localCostSummary.dailyEntries[0].totalTokens, 200)
+        XCTAssertEqual(store.localCostSummary.dailyEntries[0].costUSD, 0.001615, accuracy: 1e-12)
     }
 
     func testInitializationSeedsHistoricalModelsFromConfigThenRefreshesInBackground() throws {
@@ -520,10 +584,10 @@ final class TokenStoreSettingsTests: CodexBarTestCase {
         }
 
         XCTAssertNotNil(store.localCostSummary.updatedAt)
-        XCTAssertEqual(store.localCostSummary.last30DaysTokens, 230)
-        XCTAssertEqual(store.localCostSummary.lifetimeTokens, 230)
+        XCTAssertEqual(store.localCostSummary.last30DaysTokens, 200)
+        XCTAssertEqual(store.localCostSummary.lifetimeTokens, 200)
         XCTAssertEqual(store.localCostSummary.dailyEntries.count, 1)
-        XCTAssertEqual(store.localCostSummary.dailyEntries[0].totalTokens, 230)
+        XCTAssertEqual(store.localCostSummary.dailyEntries[0].totalTokens, 200)
     }
 
     func testSaveOpenAIAccountSettingsWritesAccountOrderModeAndManualActivationBehavior() throws {


### PR DESCRIPTION
## Summary
- 将 cached input 视为 `input_tokens` 的子集，普通输入只按 `input - cached` 计价
- token 总量改为 `input_tokens + output_tokens`，避免 cached input 重复统计
- long-context premium 改为按单次 usage 判断，而不是按整个 session 累计
- 给本地 cost cache 增加 `schemaVersion`，旧缓存会自动重建

## Why
`cached_input_tokens` 已包含在 `input_tokens` 中。旧逻辑会把 cached input 同时按普通 input 和 cached input 计价，并在 token 总量里额外加一次，导致本地 cost/tokens 偏大。

## Tests
- `xcodebuild test -project codexBar.xcodeproj -scheme codexbar -only-testing:codexbarTests/LocalCostSummaryServiceTests -only-testing:codexbarTests/TokenStoreSettingsTests -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- `xcodebuild test -project codexBar.xcodeproj -scheme codexbar -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`