### PR TITLE
修复 weekly-only 额度显示重复 7d

### DIFF
--- a/codexBar/Models/TokenAccount.swift
+++ b/codexBar/Models/TokenAccount.swift
@@ -181,28 +181,24 @@ struct TokenAccount: Codable, Identifiable {
 
     nonisolated func normalizedQuotaSnapshot(now: Date = Date()) -> TokenAccount {
         var normalized = self
-        let primaryWindowSeconds = self.resolvedPrimaryLimitWindowSeconds(now: now)
-        let secondaryWindowSeconds = self.resolvedSecondaryLimitWindowSeconds(now: now)
+        let windows = self.rateLimitWindows(now: now)
 
-        if normalized.primaryLimitWindowSeconds == nil {
-            normalized.primaryLimitWindowSeconds = primaryWindowSeconds
-        }
-        if normalized.secondaryLimitWindowSeconds == nil {
-            normalized.secondaryLimitWindowSeconds = secondaryWindowSeconds
+        if let primary = windows.first {
+            normalized.primaryUsedPercent = primary.usedPercent
+            normalized.primaryResetAt = primary.resetAt
+            normalized.primaryLimitWindowSeconds = primary.limitWindowSeconds
         }
 
-        normalized.primaryResetAt = Self.clampedResetAt(
-            self.primaryResetAt,
-            limitWindowSeconds: primaryWindowSeconds,
-            lastChecked: self.lastChecked,
-            now: now
-        )
-        normalized.secondaryResetAt = Self.clampedResetAt(
-            self.secondaryResetAt,
-            limitWindowSeconds: secondaryWindowSeconds,
-            lastChecked: self.lastChecked,
-            now: now
-        )
+        if let secondary = windows.dropFirst().first {
+            normalized.secondaryUsedPercent = secondary.usedPercent
+            normalized.secondaryResetAt = secondary.resetAt
+            normalized.secondaryLimitWindowSeconds = secondary.limitWindowSeconds
+        } else {
+            normalized.secondaryUsedPercent = 0
+            normalized.secondaryResetAt = nil
+            normalized.secondaryLimitWindowSeconds = nil
+        }
+
         return normalized
     }
 
@@ -463,7 +459,7 @@ extension TokenAccount {
             )
         }
 
-        return windows
+        return Self.deduplicatedRateLimitWindows(windows)
     }
 
     nonisolated private func effectiveResetAt(
@@ -499,6 +495,11 @@ extension TokenAccount {
             return secondaryLimitWindowSeconds
         }
 
+        let primaryWindowSeconds = self.resolvedPrimaryLimitWindowSeconds(now: now)
+        if primaryWindowSeconds == 7 * 86_400 {
+            return nil
+        }
+
         if self.secondaryResetAt != nil || self.secondaryUsedPercent > 0 {
             return 7 * 86_400
         }
@@ -517,6 +518,58 @@ extension TokenAccount {
         }
 
         return nil
+    }
+
+    nonisolated private static func deduplicatedRateLimitWindows(
+        _ windows: [RateLimitWindowSnapshot]
+    ) -> [RateLimitWindowSnapshot] {
+        var result: [RateLimitWindowSnapshot] = []
+        for window in windows {
+            if let index = result.firstIndex(where: { sameQuotaWindow($0, window) }) {
+                result[index] = self.mergedDuplicateQuotaWindow(result[index], window)
+            } else {
+                result.append(window)
+            }
+        }
+
+        return result.sorted {
+            switch ($0.limitWindowSeconds, $1.limitWindowSeconds) {
+            case let (lhs?, rhs?) where lhs != rhs:
+                return lhs < rhs
+            case (nil, _?):
+                return false
+            case (_?, nil):
+                return true
+            default:
+                return false
+            }
+        }
+    }
+
+    nonisolated private static func sameQuotaWindow(
+        _ lhs: RateLimitWindowSnapshot,
+        _ rhs: RateLimitWindowSnapshot
+    ) -> Bool {
+        lhs.limitWindowSeconds == rhs.limitWindowSeconds
+    }
+
+    nonisolated private static func mergedDuplicateQuotaWindow(
+        _ existing: RateLimitWindowSnapshot,
+        _ incoming: RateLimitWindowSnapshot
+    ) -> RateLimitWindowSnapshot {
+        if incoming.usedPercent > existing.usedPercent {
+            return incoming
+        }
+        if incoming.usedPercent < existing.usedPercent {
+            return existing
+        }
+
+        let resetAt = [existing.resetAt, incoming.resetAt].compactMap { $0 }.max()
+        return RateLimitWindowSnapshot(
+            usedPercent: existing.usedPercent,
+            resetAt: resetAt,
+            limitWindowSeconds: existing.limitWindowSeconds
+        )
     }
 
     nonisolated private func windowLabel(for seconds: Int?) -> String {

--- a/codexBar/Services/WhamService.swift
+++ b/codexBar/Services/WhamService.swift
@@ -216,49 +216,116 @@ class WhamService {
 
     func parseUsage(_ json: [String: Any]) -> WhamUsageResult {
         let planType = json["plan_type"] as? String ?? "free"
-        var primaryUsedPercent: Double = 0
-        var secondaryUsedPercent: Double = 0
-        var primaryResetAt: Date? = nil
-        var secondaryResetAt: Date? = nil
-        var primaryLimitWindowSeconds: Int? = nil
-        var secondaryLimitWindowSeconds: Int? = nil
+        var windows: [ParsedRateLimitWindow] = []
 
         if let rateLimit = json["rate_limit"] as? [String: Any] {
             if let primary = rateLimit["primary_window"] as? [String: Any] {
-                primaryUsedPercent = primary["used_percent"] as? Double ?? 0
-                if let seconds = primary["limit_window_seconds"] as? Int {
-                    primaryLimitWindowSeconds = seconds
-                } else if let seconds = primary["limit_window_seconds"] as? Double {
-                    primaryLimitWindowSeconds = Int(seconds)
-                }
-                if let ts = primary["reset_at"] as? TimeInterval {
-                    primaryResetAt = Date(timeIntervalSince1970: ts)
+                if let window = self.parseRateLimitWindow(primary) {
+                    windows.append(window)
                 }
             }
 
             if let secondary = rateLimit["secondary_window"] as? [String: Any] {
-                secondaryUsedPercent = secondary["used_percent"] as? Double ?? 0
-                if let seconds = secondary["limit_window_seconds"] as? Int {
-                    secondaryLimitWindowSeconds = seconds
-                } else if let seconds = secondary["limit_window_seconds"] as? Double {
-                    secondaryLimitWindowSeconds = Int(seconds)
-                }
-                if let ts = secondary["reset_at"] as? TimeInterval {
-                    secondaryResetAt = Date(timeIntervalSince1970: ts)
+                if let window = self.parseRateLimitWindow(secondary) {
+                    windows.append(window)
                 }
             }
         }
 
+        let normalizedWindows = self.deduplicatedRateLimitWindows(windows)
+        let primary = normalizedWindows.first
+        let secondary = normalizedWindows.dropFirst().first
+
         return WhamUsageResult(
             planType: planType,
-            primaryUsedPercent: primaryUsedPercent,
-            secondaryUsedPercent: secondaryUsedPercent,
-            primaryResetAt: primaryResetAt,
-            secondaryResetAt: secondaryResetAt,
-            primaryLimitWindowSeconds: primaryLimitWindowSeconds,
-            secondaryLimitWindowSeconds: secondaryLimitWindowSeconds
+            primaryUsedPercent: primary?.usedPercent ?? 0,
+            secondaryUsedPercent: secondary?.usedPercent ?? 0,
+            primaryResetAt: primary?.resetAt,
+            secondaryResetAt: secondary?.resetAt,
+            primaryLimitWindowSeconds: primary?.limitWindowSeconds,
+            secondaryLimitWindowSeconds: secondary?.limitWindowSeconds
         )
     }
+
+    private func parseRateLimitWindow(_ window: [String: Any]) -> ParsedRateLimitWindow? {
+        let usedPercent = window["used_percent"] as? Double ?? 0
+        let limitWindowSeconds: Int?
+        if let seconds = window["limit_window_seconds"] as? Int {
+            limitWindowSeconds = seconds
+        } else if let seconds = window["limit_window_seconds"] as? Double {
+            limitWindowSeconds = Int(seconds)
+        } else {
+            limitWindowSeconds = nil
+        }
+
+        let resetAt: Date?
+        if let ts = window["reset_at"] as? TimeInterval {
+            resetAt = Date(timeIntervalSince1970: ts)
+        } else {
+            resetAt = nil
+        }
+
+        guard limitWindowSeconds != nil || resetAt != nil || usedPercent > 0 else {
+            return nil
+        }
+
+        return ParsedRateLimitWindow(
+            usedPercent: usedPercent,
+            resetAt: resetAt,
+            limitWindowSeconds: limitWindowSeconds
+        )
+    }
+
+    private func deduplicatedRateLimitWindows(
+        _ windows: [ParsedRateLimitWindow]
+    ) -> [ParsedRateLimitWindow] {
+        var result: [ParsedRateLimitWindow] = []
+        for window in windows {
+            if let index = result.firstIndex(where: { $0.limitWindowSeconds == window.limitWindowSeconds }) {
+                result[index] = self.mergedDuplicateRateLimitWindow(result[index], window)
+            } else {
+                result.append(window)
+            }
+        }
+
+        return result.sorted {
+            switch ($0.limitWindowSeconds, $1.limitWindowSeconds) {
+            case let (lhs?, rhs?) where lhs != rhs:
+                return lhs < rhs
+            case (nil, _?):
+                return false
+            case (_?, nil):
+                return true
+            default:
+                return false
+            }
+        }
+    }
+
+    private func mergedDuplicateRateLimitWindow(
+        _ existing: ParsedRateLimitWindow,
+        _ incoming: ParsedRateLimitWindow
+    ) -> ParsedRateLimitWindow {
+        if incoming.usedPercent > existing.usedPercent {
+            return incoming
+        }
+        if incoming.usedPercent < existing.usedPercent {
+            return existing
+        }
+
+        let resetAt = [existing.resetAt, incoming.resetAt].compactMap { $0 }.max()
+        return ParsedRateLimitWindow(
+            usedPercent: existing.usedPercent,
+            resetAt: resetAt,
+            limitWindowSeconds: existing.limitWindowSeconds
+        )
+    }
+}
+
+private struct ParsedRateLimitWindow {
+    let usedPercent: Double
+    let resetAt: Date?
+    let limitWindowSeconds: Int?
 }
 
 struct WhamUsageResult {

--- a/codexBarTests/TokenAccountHeaderQuotaRemarkTests.swift
+++ b/codexBarTests/TokenAccountHeaderQuotaRemarkTests.swift
@@ -265,6 +265,45 @@ final class TokenAccountHeaderQuotaRemarkTests: XCTestCase {
         XCTAssertEqual(account.usageWindowDisplays.map(\.label), ["7d"])
     }
 
+    func testPlusWeeklyOnlySnapshotShowsSingleSevenDayWindow() {
+        let account = makeAccount(
+            planType: "plus",
+            primaryUsedPercent: 0,
+            secondaryUsedPercent: 0,
+            primaryLimitWindowSeconds: 604_800
+        )
+
+        XCTAssertEqual(account.usageWindowDisplays.map(\.label), ["7d"])
+        XCTAssertEqual(account.compactUsageSummary(mode: .remaining), "7d 100%")
+    }
+
+    func testDuplicateWeeklyWindowsAreCollapsedForDisplayAndPersistence() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let primaryResetAt = now.addingTimeInterval(2 * 86_400)
+        let secondaryResetAt = now.addingTimeInterval(5 * 86_400)
+        let account = makeAccount(
+            planType: "plus",
+            primaryUsedPercent: 42,
+            secondaryUsedPercent: 87,
+            primaryResetAt: primaryResetAt,
+            secondaryResetAt: secondaryResetAt,
+            primaryLimitWindowSeconds: 604_800,
+            secondaryLimitWindowSeconds: 604_800,
+            lastChecked: now
+        )
+
+        XCTAssertEqual(account.usageWindowDisplays.map(\.label), ["7d"])
+        XCTAssertEqual(account.compactUsageSummary(mode: .used), "7d 87%")
+
+        let normalized = account.normalizedQuotaSnapshot(now: now)
+        XCTAssertEqual(normalized.primaryUsedPercent, 87)
+        XCTAssertEqual(normalized.primaryResetAt, secondaryResetAt)
+        XCTAssertEqual(normalized.primaryLimitWindowSeconds, 604_800)
+        XCTAssertEqual(normalized.secondaryUsedPercent, 0)
+        XCTAssertNil(normalized.secondaryResetAt)
+        XCTAssertNil(normalized.secondaryLimitWindowSeconds)
+    }
+
     func testPlusAccountShowsBothUsageWindowLabels() {
         let account = makeAccount(
             primaryUsedPercent: 10,

--- a/codexBarTests/WhamServiceParsingTests.swift
+++ b/codexBarTests/WhamServiceParsingTests.swift
@@ -65,4 +65,29 @@ final class WhamServiceParsingTests: XCTestCase {
         XCTAssertEqual(result.secondaryUsedPercent, 0)
         XCTAssertNotNil(result.secondaryResetAt)
     }
+
+    func testDuplicateWeeklyWindowsAreCollapsedWhenParsingUsage() {
+        let result = WhamService.shared.parseUsage([
+            "plan_type": "plus",
+            "rate_limit": [
+                "primary_window": [
+                    "used_percent": 42.0,
+                    "limit_window_seconds": 604_800,
+                    "reset_at": 1_775_372_003.0,
+                ],
+                "secondary_window": [
+                    "used_percent": 87.0,
+                    "limit_window_seconds": 604_800,
+                    "reset_at": 1_775_690_771.0,
+                ],
+            ],
+        ])
+
+        XCTAssertEqual(result.primaryLimitWindowSeconds, 604_800)
+        XCTAssertNil(result.secondaryLimitWindowSeconds)
+        XCTAssertEqual(result.primaryUsedPercent, 87)
+        XCTAssertEqual(result.secondaryUsedPercent, 0)
+        XCTAssertEqual(result.primaryResetAt, Date(timeIntervalSince1970: 1_775_690_771.0))
+        XCTAssertNil(result.secondaryResetAt)
+    }
 }


### PR DESCRIPTION
## 背景

当前 `main` 在付费账号只有一个 weekly quota window 时，会显示重复的 `7d` 窗口。

我在 `origin/main` (`aeca09f`) 上加了一个最小复现测试：Plus 账号只有 `primaryLimitWindowSeconds = 604800` 时，当前实际输出是：

```text
["7d", "7d"]
7d 100% · 7d 100%
```

这个结果来自两个行为叠加：

- `WhamService.parseUsage` 直接把 `primary_window` / `secondary_window` 原样写入，没有合并相同 `limit_window_seconds` 的窗口。
- `TokenAccount.resolvedSecondaryLimitWindowSeconds` 会为 Plus/Pro/Team 默认推断一个 `7d` secondary window，即使 primary window 已经是 `7d`。

## 修改

- 在 Wham usage 解析阶段把 quota windows 规范化：
  - 合并相同 `limit_window_seconds` 的窗口；
  - 保留使用率更高的窗口作为更保守快照；
  - 按窗口长度排序，保持 `5h · 7d` 的显示顺序。
- 在 `TokenAccount` 展示与归一化阶段合并重复窗口。
- 当 primary window 已经是 `7d` 时，不再为付费账号额外推断一个 secondary `7d`。
- 增加测试覆盖：
  - weekly-only Plus 账号只显示一个 `7d`；
  - 已持久化的 `7d + 7d` 会归一成单个 weekly window；
  - Wham 返回重复 weekly windows 时会被解析合并。

## 验证

```bash
xcodebuild test \
  -project codexBar.xcodeproj \
  -scheme codexbar \
  -only-testing:codexbarTests/WhamServiceParsingTests \
  -only-testing:codexbarTests/TokenAccountHeaderQuotaRemarkTests \
  -destination 'platform=macOS' \
  CODE_SIGNING_ALLOWED=NO \
  CODE_SIGNING_REQUIRED=NO
```

结果：26 tests, 0 failures。

```bash
xcodebuild test \
  -project codexBar.xcodeproj \
  -scheme codexbar \
  -destination 'platform=macOS' \
  CODE_SIGNING_ALLOWED=NO \
  CODE_SIGNING_REQUIRED=NO
```

结果：479 tests, 0 failures。
